### PR TITLE
fix php8.1 warning Hooks.php

### DIFF
--- a/src/Library/Hooks.php
+++ b/src/Library/Hooks.php
@@ -53,15 +53,19 @@ class Hooks {
 
         foreach ( $arrTables as $strTable ) {
 
-            if ( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['useExport'] ) {
+            if ( isset($GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]) ) {
+                
+                if ( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['useExport'] ) {
 
-                return true;
+                    return true;
+                }
+    
+                if ( !empty( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['cTables'] ) ) {
+    
+                    return $this->exportUsedInChildrenTables( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['cTables'] );
+                }
             }
-
-            if ( !empty( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['cTables'] ) ) {
-
-                return $this->exportUsedInChildrenTables( $GLOBALS['TL_CATALOG_MANAGER']['CATALOG_EXTENSIONS'][ $strTable ]['cTables'] );
-            }
+            
         }
 
         return false;


### PR DESCRIPTION
$strTable can be empty, but foreach use it
PHP8.1
Contao 4.13.52
Catalog Manager v1.32.51
Catalog Manager Export v1.3.0